### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -50,4 +50,6 @@ def httpsflaskexample(req: https_fn.Request) -> https_fn.Response:
         return app.full_dispatch_request()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/chenyuan99/TaxFront/security/code-scanning/1](https://github.com/chenyuan99/TaxFront/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Import the `os` module to access environment variables.
2. Modify the `app.run()` method to set the `debug` parameter based on an environment variable.
3. Set a default value for the environment variable to ensure that debug mode is disabled by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
